### PR TITLE
Add ifaces for JoinDialog, add ValidatorChain

### DIFF
--- a/src/main/kotlin/Validating.kt
+++ b/src/main/kotlin/Validating.kt
@@ -1,11 +1,14 @@
 package com.dmdirc
 
 import javafx.beans.binding.BooleanExpression
+import javafx.beans.property.ReadOnlyBooleanPropertyBase
 import javafx.beans.property.StringProperty
 import javafx.scene.control.TextField
 import javafx.scene.control.TextInputControl
+import kotlinx.atomicfu.atomic
 import org.controlsfx.validation.ValidationSupport
 import org.controlsfx.validation.Validator
+import tornadofx.ChangeListener
 
 val requiredValidator: Validator<TextField> = Validator.createEmptyValidator<TextField>("Required")
 
@@ -16,10 +19,43 @@ fun bindRequiredTextControl(c: TextInputControl, p: StringProperty, m: Validatin
 fun bindTextControl(c: TextInputControl, p: StringProperty, v: Validator<TextField>, m: ValidatingModel) {
     val validationSupport = ValidationSupport()
     validationSupport.registerValidator(c, v)
-    m.addValidator(validationSupport.invalidProperty())
+    m.valid.addValidator(validationSupport.invalidProperty())
     p.bindBidirectional(c.textProperty())
 }
 
 interface ValidatingModel {
-    fun addValidator(validator: BooleanExpression)
+    val valid: ValidatorChain
+}
+
+/**
+ * Manages a chain of validators that must all pass in order for the overall validation state to be true.
+ *
+ * If no validators are supplied, validation fails. Listeners are only notified when the overall validation
+ * state changes.
+ */
+class ValidatorChain : ReadOnlyBooleanPropertyBase() {
+
+    private val validators = mutableListOf<BooleanExpression>()
+    private var valid = atomic(false)
+
+    private val listener = ChangeListener<Boolean> { _, _, _ -> recompute() }
+
+    override fun getName() = ""
+    override fun getBean() = null
+
+    override fun get() = validators.isNotEmpty() && validators.all { it.get() }
+
+    fun addValidator(validator: BooleanExpression) {
+        validators.add(validator)
+        validator.addListener(listener)
+        recompute()
+    }
+
+    private fun recompute() {
+        val newValue = get()
+        if (valid.compareAndSet(!newValue, newValue)) {
+            fireValueChangedEvent()
+        }
+    }
+
 }

--- a/src/main/kotlin/Validating.kt
+++ b/src/main/kotlin/Validating.kt
@@ -3,12 +3,12 @@ package com.dmdirc
 import javafx.beans.binding.BooleanExpression
 import javafx.beans.property.ReadOnlyBooleanPropertyBase
 import javafx.beans.property.StringProperty
+import javafx.beans.value.ChangeListener
 import javafx.scene.control.TextField
 import javafx.scene.control.TextInputControl
 import kotlinx.atomicfu.atomic
 import org.controlsfx.validation.ValidationSupport
 import org.controlsfx.validation.Validator
-import tornadofx.ChangeListener
 
 val requiredValidator: Validator<TextField> = Validator.createEmptyValidator<TextField>("Required")
 

--- a/src/test/kotlin/ValidatorChainTest.kt
+++ b/src/test/kotlin/ValidatorChainTest.kt
@@ -1,0 +1,85 @@
+import com.dmdirc.ValidatorChain
+import io.mockk.mockk
+import io.mockk.verify
+import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.value.ChangeListener
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class ValidatorChainTest {
+
+    private val chain = ValidatorChain()
+
+    @Test
+    fun `is invalid by default`() {
+        assertFalse(chain.value)
+    }
+
+    @Test
+    fun `becomes valid when a passing validator is added`() {
+        chain.addValidator(SimpleBooleanProperty(true))
+        assertTrue(chain.value)
+    }
+
+    @Test
+    fun `remains invalid when a failing validator is added`() {
+        chain.addValidator(SimpleBooleanProperty(false))
+        assertFalse(chain.value)
+    }
+
+    @Test
+    fun `listens for changes to added validators`() {
+        val prop = SimpleBooleanProperty(false)
+        chain.addValidator(prop)
+        assertFalse(chain.value)
+        prop.set(true)
+        assertTrue(chain.value)
+    }
+
+    @Test
+    fun `notifies listeners when a new validator affects its state`() {
+        val listener = mockk<ChangeListener<Boolean>>()
+        chain.addListener(listener)
+        chain.addValidator(SimpleBooleanProperty(true))
+        verify { listener.changed(chain, false, true) }
+    }
+
+    @Test
+    fun `does not notify listeners when a new validator doesn't affect its state`() {
+        chain.addValidator(SimpleBooleanProperty(true))
+
+        val listener = mockk<ChangeListener<Boolean>>()
+        chain.addListener(listener)
+        chain.addValidator(SimpleBooleanProperty(true))
+        verify(inverse = true) { listener.changed(refEq(chain), any(), any()) }
+    }
+
+    @Test
+    fun `notifies listeners when a validator causes the state to change`() {
+        val prop = SimpleBooleanProperty(true)
+        chain.addValidator(prop)
+
+        val listener = mockk<ChangeListener<Boolean>>()
+        chain.addListener(listener)
+
+        prop.set(false)
+
+        verify { listener.changed(chain, true, false) }
+    }
+
+    @Test
+    fun `does not notify listeners when a validator is updated but doesn't affect its state`() {
+        val prop = SimpleBooleanProperty(true)
+        chain.addValidator(prop)
+        chain.addValidator(SimpleBooleanProperty(false))
+
+        val listener = mockk<ChangeListener<Boolean>>()
+        chain.addListener(listener)
+
+        prop.set(false)
+
+        verify(inverse = true) { listener.changed(refEq(chain), any(), any()) }
+    }
+
+}


### PR DESCRIPTION
Interfaces to enable testing and make it obvious which each
part is for.

ValidatorChain handles adding multiple boolean validators
(one for each field, for example), tracking their values,
and defaulting to `false` before validators are added.