### PR TITLE
Stop duplicate class spam in drone.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,7 @@ tasks {
             put("Main-Class", mainClass)
         }
         from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
 
 }


### PR DESCRIPTION
I think this is because the win/linux/mac runtimes contain a
lot of the same classes.