### PR TITLE
Insert windows in sorted order

### DIFF
--- a/src/main/kotlin/com/dmdirc/MainController.kt
+++ b/src/main/kotlin/com/dmdirc/MainController.kt
@@ -42,12 +42,12 @@ class MainController(
 
     override fun connect(connectionDetails: ConnectionDetails) {
         with(connectionFactory(connectionDetails)) {
-            windows.addAll(children.map { it.model })
+            windows.insertSorted(children.map { it.model })
             selectedWindow.value = model
             children.observable.addListener(SetChangeListener<Connection.Child> {
                 runLater {
                     when {
-                        it.wasAdded() -> windows.add(it.elementAdded.model)
+                        it.wasAdded() -> windows.insertSorted(it.elementAdded.model)
                         it.wasRemoved() -> windows.remove(it.elementRemoved.model)
                     }
                 }
@@ -63,4 +63,12 @@ class MainController(
     override fun leaveChannel(channel: String) {
         selectedWindow.value.connection?.leaveChannel(channel)
     }
+}
+
+fun ObservableList<WindowModel>.insertSorted(model: WindowModel) = indexOfFirst { it.sortKey > model.sortKey }.let {
+    add(if (it == -1) size else it, model)
+}
+
+fun ObservableList<WindowModel>.insertSorted(models: Collection<WindowModel>) {
+    models.forEach { insertSorted(it) }
 }

--- a/src/main/kotlin/com/dmdirc/MainView.kt
+++ b/src/main/kotlin/com/dmdirc/MainView.kt
@@ -6,7 +6,6 @@ import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
 import javafx.beans.property.ObjectProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.StringProperty
-import javafx.collections.transformation.SortedList
 import javafx.event.EventHandler
 import javafx.geometry.Pos
 import javafx.scene.Node
@@ -173,7 +172,7 @@ class MainView(
                     })
                 })
             }
-            left = ListView(SortedList(controller.windows, compareBy { it.sortKey })).apply {
+            left = ListView(controller.windows).apply {
                 styleClass.add("tree-view")
                 selectionModel.selectedItemProperty().addListener { _, _, newValue ->
                     controller.selectedWindow.value = newValue


### PR DESCRIPTION
This means we don't need a SortedList which is apparently really
stupid and raises permutation events every time anything changes,
which in turn makes our treeview deselect nodes briefly which
causes lots of problems.

Closes #200