### PR TITLE
Initial attempt at some thread safety

### DIFF
--- a/src/main/kotlin/com/dmdirc/App.kt
+++ b/src/main/kotlin/com/dmdirc/App.kt
@@ -3,15 +3,9 @@ package com.dmdirc
 import com.bugsnag.Bugsnag
 import javafx.application.Application
 import javafx.application.HostServices
-import javafx.application.Platform
 import javafx.beans.property.ObjectProperty
-import javafx.beans.property.Property
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.StringProperty
-import javafx.collections.FXCollections
-import javafx.collections.ObservableList
-import javafx.collections.ObservableMap
-import javafx.collections.ObservableSet
 import javafx.scene.Node
 import javafx.scene.Scene
 import javafx.stage.Stage
@@ -107,21 +101,4 @@ private fun createKodein(
 fun main() {
     LogManager.getLogManager().readConfiguration(MainApp::class.java.getResourceAsStream("/logs.properties"))
     Application.launch(MainApp::class.java)
-}
-
-fun <T> List<T>.observable(): ObservableList<T> = FXCollections.observableList(this)
-fun <T> Set<T>.observable(): ObservableSet<T> = FXCollections.observableSet(this)
-fun <T> ObservableSet<T>.synchronized(): ObservableSet<T> = FXCollections.synchronizedObservableSet(this)
-fun <T> ObservableSet<T>.readOnly(): ObservableSet<T> = FXCollections.unmodifiableObservableSet(this)
-fun <K, V> Map<K, V>.observable(): ObservableMap<K, V> = FXCollections.observableMap(this)
-
-// For testing purposes: we can swap out the Platform call to something we control
-internal var runLaterProvider: (Runnable) -> Unit = Platform::runLater
-
-fun runLater(block: () -> Unit) = runLaterProvider(Runnable(block))
-
-fun <T, Y> Property<T>.bindTransform(other: Property<Y>, biFunction: (T, T) -> Y) {
-    addListener { _, oldValue, newValue ->
-        other.value = biFunction(oldValue, newValue)
-    }
 }

--- a/src/main/kotlin/com/dmdirc/Connection.kt
+++ b/src/main/kotlin/com/dmdirc/Connection.kt
@@ -20,7 +20,7 @@ import com.dmdirc.ktirc.model.ChannelUser
 import com.dmdirc.ktirc.model.ServerFeature
 import com.dmdirc.ktirc.model.ServerStatus
 import javafx.application.HostServices
-import javafx.beans.property.BooleanProperty
+import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.collections.ObservableSet
 import javafx.scene.Node
@@ -32,7 +32,7 @@ private val connectionCounter = AtomicLong(0)
 object ConnectionContract {
     interface Controller {
         val children: Connection.WindowMap
-        val connected: BooleanProperty
+        val connected: Property<Boolean>
         val model: WindowModel
         var networkName: String
         fun connect()
@@ -57,7 +57,7 @@ class Connection(
         connectionDetails.hostname, WindowType.SERVER, this, config1, connectionId
     )
 
-    override val connected = SimpleBooleanProperty(false)
+    override val connected = SimpleBooleanProperty(false).threadAsserting()
 
     override val children = WindowMap { client.caseMapping }.apply {
         this += Child(model, WindowUI(model, hostServices))

--- a/src/main/kotlin/com/dmdirc/FxUtils.kt
+++ b/src/main/kotlin/com/dmdirc/FxUtils.kt
@@ -1,0 +1,100 @@
+package com.dmdirc
+
+import com.bugsnag.Bugsnag
+import com.dmdirc.PlatformWrappers.fxThreadTester
+import com.dmdirc.PlatformWrappers.runLaterProvider
+import javafx.application.Platform
+import javafx.beans.InvalidationListener
+import javafx.beans.binding.BooleanBinding
+import javafx.beans.property.Property
+import javafx.beans.value.ChangeListener
+import javafx.beans.value.ObservableValue
+import javafx.collections.FXCollections
+import javafx.collections.ObservableList
+import javafx.collections.ObservableMap
+import javafx.collections.ObservableSet
+import org.kodein.di.direct
+import org.kodein.di.generic.instance
+
+fun <T> List<T>.observable(): ObservableList<T> = FXCollections.observableList(this)
+fun <T> Set<T>.observable(): ObservableSet<T> = FXCollections.observableSet(this)
+fun <T> ObservableSet<T>.synchronized(): ObservableSet<T> = FXCollections.synchronizedObservableSet(this)
+fun <T> ObservableSet<T>.readOnly(): ObservableSet<T> = FXCollections.unmodifiableObservableSet(this)
+fun <K, V> Map<K, V>.observable(): ObservableMap<K, V> = FXCollections.observableMap(this)
+
+fun <T, Y> Property<T>.bindTransform(other: Property<Y>, biFunction: (T, T) -> Y) {
+    addListener { _, oldValue, newValue ->
+        other.value = biFunction(oldValue, newValue)
+    }
+}
+
+fun runLater(block: () -> Unit) = runLaterProvider(Runnable(block))
+
+fun assertOnFxThread(bugsnag: Bugsnag? = null) {
+    if (!fxThreadTester()) {
+        val stackTrace = Throwable().stackTrace
+        val method = stackTrace[1].methodName
+        val exception =
+            WrongThreadException("Function $method must be called on the FX thread. Current thread: ${Thread.currentThread().name}")
+        exception.stackTrace = stackTrace.sliceArray(2 until stackTrace.size)
+        (bugsnag ?: kodein.direct.instance()).notify(exception)
+    }
+}
+
+/**
+ * Implements the [Property] interface and proxies all methods to the parent.
+ *
+ * Useful if you want to override one method and leave all the others alone.
+ */
+@Suppress("UsePropertyAccessSyntax")
+internal abstract class ProxyProperty<T>(private val parent: Property<T>) : Property<T> {
+    override fun setValue(value: T) = parent.setValue(value)
+    override fun getName(): String = parent.name
+    override fun bindBidirectional(other: Property<T>?) = parent.bindBidirectional(other)
+    override fun addListener(listener: ChangeListener<in T>?) = parent.addListener(listener)
+    override fun addListener(listener: InvalidationListener?) = parent.addListener(listener)
+    override fun getBean(): Any = parent.bean
+    override fun unbind() = parent.unbind()
+    override fun removeListener(listener: ChangeListener<in T>?) = parent.removeListener(listener)
+    override fun removeListener(listener: InvalidationListener?) = parent.removeListener(listener)
+    override fun bind(observable: ObservableValue<out T>?) = parent.bind(observable)
+    override fun isBound(): Boolean = parent.isBound
+    override fun getValue(): T = parent.value
+    override fun unbindBidirectional(other: Property<T>?) = parent.unbindBidirectional(other)
+}
+
+/**
+ * Creates a proxy over the property that asserts that sets are always performed on the correct thread.
+ */
+fun <T> Property<T>.threadAsserting(): Property<T> = object : ProxyProperty<T>(this) {
+    override fun setValue(value: T) {
+        assertOnFxThread()
+        super.setValue(value)
+    }
+}
+
+fun Property<Boolean>.not() = object : BooleanBinding() {
+    init {
+        super.bind(this@not)
+    }
+    override fun dispose() = super.unbind(this@not)
+    override fun computeValue() = !this@not.value
+    override fun getDependencies() = FXCollections.singletonObservableList<Property<Boolean>>(this@not)
+}
+
+fun Property<*>.isNull() = object : BooleanBinding() {
+    init {
+        super.bind(this@isNull)
+    }
+    override fun dispose() = super.unbind(this@isNull)
+    override fun computeValue() = this@isNull.value == null
+    override fun getDependencies() = FXCollections.singletonObservableList<Property<*>>(this@isNull)
+}
+
+internal class WrongThreadException(message: String) : RuntimeException(message)
+
+// For testing purposes: we can swap out the Platform calls to something we control
+internal object PlatformWrappers {
+    internal var runLaterProvider: (Runnable) -> Unit = Platform::runLater
+    internal var fxThreadTester: () -> Boolean = Platform::isFxApplicationThread
+}

--- a/src/main/kotlin/com/dmdirc/JoinDialog.kt
+++ b/src/main/kotlin/com/dmdirc/JoinDialog.kt
@@ -2,11 +2,10 @@ package com.dmdirc
 
 import com.jukusoft.i18n.I
 import com.jukusoft.i18n.I.tr
-import javafx.beans.property.BooleanProperty
 import javafx.beans.property.ObjectProperty
+import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleStringProperty
-import javafx.beans.property.StringProperty
 import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.control.Button
@@ -22,8 +21,8 @@ object JoinDialogContract {
     }
 
     interface ViewModel : ValidatingModel {
-        val open: BooleanProperty
-        val channel: StringProperty
+        val open: Property<Boolean>
+        val channel: Property<String>
         fun onTextAction()
         fun onJoinPressed()
         fun onCancelPressed()
@@ -38,8 +37,8 @@ class JoinDialogController(private val controller: MainContract.Controller) : Jo
 
 class JoinDialogModel(private val controller: JoinDialogContract.Controller) : JoinDialogContract.ViewModel {
 
-    override val open = SimpleBooleanProperty(true)
-    override val channel = SimpleStringProperty()
+    override val open = SimpleBooleanProperty(true).threadAsserting()
+    override val channel = SimpleStringProperty().threadAsserting()
     override val valid = ValidatorChain()
 
     private fun commit() {
@@ -50,7 +49,9 @@ class JoinDialogModel(private val controller: JoinDialogContract.Controller) : J
         close()
     }
 
-    private fun close() = open.set(false)
+    private fun close() {
+        open.value = false
+    }
 
     override fun onTextAction() = commit()
     override fun onJoinPressed() = commit()

--- a/src/main/kotlin/com/dmdirc/MainController.kt
+++ b/src/main/kotlin/com/dmdirc/MainController.kt
@@ -1,6 +1,6 @@
 package com.dmdirc
 
-import javafx.beans.property.ObjectProperty
+import javafx.beans.property.Property
 import javafx.beans.property.SimpleObjectProperty
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
@@ -9,7 +9,7 @@ import javafx.collections.SetChangeListener
 object MainContract {
     interface Controller {
         val windows: ObservableList<WindowModel>
-        val selectedWindow: ObjectProperty<WindowModel>
+        val selectedWindow: Property<WindowModel>
         fun connect(connectionDetails: ConnectionDetails)
         fun joinChannel(channel: String)
         fun leaveChannel(channel: String)
@@ -30,7 +30,7 @@ class MainController(
     }
 
     override val windows: ObservableList<WindowModel> = FXCollections.observableArrayList(WindowModel.extractor())
-    override val selectedWindow = SimpleObjectProperty<WindowModel>()
+    override val selectedWindow = SimpleObjectProperty<WindowModel>().threadAsserting()
 
     init {
         autoConnect()

--- a/src/main/kotlin/com/dmdirc/MainView.kt
+++ b/src/main/kotlin/com/dmdirc/MainView.kt
@@ -44,7 +44,7 @@ class ServerContextMenu(
             setOnAction {
                 joinDialogProvider().show()
             }
-            disableProperty().bind(controller.selectedWindow.isNull)
+            disableProperty().bind(controller.selectedWindow.isNull())
         }, MenuItem(tr("Disconnect")).apply {
             visibleProperty().bind(connection?.connected)
             setOnAction {
@@ -206,8 +206,8 @@ class MainView(
         titleProperty.bindBidirectional(controller.selectedWindow, TitleStringConverter())
         controller.selectedWindow.addListener { _, oldValue, newValue ->
             runLater {
-                oldValue?.hasUnreadMessages?.set(false)
-                newValue?.hasUnreadMessages?.set(false)
+                oldValue?.hasUnreadMessages?.value = false
+                newValue?.hasUnreadMessages?.value = false
                 selectedWindow.value = newValue?.let {
                     it.connection?.children?.get(it.name.value)?.ui
                 } ?: VBox()

--- a/src/main/kotlin/com/dmdirc/ServerlistDialog.kt
+++ b/src/main/kotlin/com/dmdirc/ServerlistDialog.kt
@@ -4,8 +4,8 @@ import com.jukusoft.i18n.I.tr
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.EYE
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon.EYE_SLASH
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView
-import javafx.beans.property.BooleanProperty
 import javafx.beans.property.ObjectProperty
+import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
@@ -48,15 +48,15 @@ object ServerListDialogContract {
         fun closeDialog()
         fun show()
 
-        val open: BooleanProperty
+        val open: Property<Boolean>
         val servers: ObservableList<ConnectionDetailsEditable>
-        val selected: ObjectProperty<ConnectionDetailsEditable>
-        val hostname: StringProperty
-        val password: StringProperty
-        val editEnabled: BooleanProperty
-        val port: StringProperty
-        val tls: BooleanProperty
-        val autoconnect: BooleanProperty
+        val selected: Property<ConnectionDetailsEditable>
+        val hostname: Property<String>
+        val password: Property<String>
+        val editEnabled: Property<Boolean>
+        val port: Property<String>
+        val tls: Property<Boolean>
+        val autoconnect: Property<Boolean>
     }
 }
 
@@ -94,15 +94,15 @@ class ServerListModel(
     private val config: ClientConfig
 ) : ServerListDialogContract.ViewModel {
     override val valid = ValidatorChain()
-    override val open = SimpleBooleanProperty(true)
+    override val open = SimpleBooleanProperty(true).threadAsserting()
     override val servers = emptyList<ConnectionDetailsEditable>().toMutableList().observable()
-    override val selected = SimpleObjectProperty<ConnectionDetailsEditable>()
-    override val hostname = SimpleStringProperty()
-    override val password = SimpleStringProperty()
-    override val port = SimpleStringProperty()
-    override val tls = SimpleBooleanProperty()
-    override val autoconnect = SimpleBooleanProperty()
-    override val editEnabled = SimpleBooleanProperty()
+    override val selected = SimpleObjectProperty<ConnectionDetailsEditable>().threadAsserting()
+    override val hostname = SimpleStringProperty().threadAsserting()
+    override val password = SimpleStringProperty().threadAsserting()
+    override val port = SimpleStringProperty().threadAsserting()
+    override val tls = SimpleBooleanProperty().threadAsserting()
+    override val autoconnect = SimpleBooleanProperty().threadAsserting()
+    override val editEnabled = SimpleBooleanProperty().threadAsserting()
 
     init {
         selected.addListener { _, oldValue, newValue ->

--- a/src/main/kotlin/com/dmdirc/SettingsDialog.kt
+++ b/src/main/kotlin/com/dmdirc/SettingsDialog.kt
@@ -1,11 +1,10 @@
 package com.dmdirc
 
 import com.jukusoft.i18n.I.tr
-import javafx.beans.property.BooleanProperty
 import javafx.beans.property.ObjectProperty
+import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleStringProperty
-import javafx.beans.property.StringProperty
 import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.control.Button
@@ -23,10 +22,10 @@ object SettingsDialogContract {
     }
 
     interface ViewModel : ValidatingModel {
-        val open: BooleanProperty
-        val nickname: StringProperty
-        val realname: StringProperty
-        val username: StringProperty
+        val open: Property<Boolean>
+        val nickname: Property<String>
+        val realname: Property<String>
+        val username: Property<String>
         fun onSavePressed()
         fun onCancelPressed()
     }
@@ -45,10 +44,10 @@ class SettingsDialogController(private val config: ClientConfig) : SettingsDialo
 class SettingsDialogModel(private val controller: SettingsDialogContract.Controller, config: ClientConfig) :
     SettingsDialogContract.ViewModel {
     override val valid = ValidatorChain()
-    override val open = SimpleBooleanProperty(true)
-    override val nickname = SimpleStringProperty(config[ClientSpec.DefaultProfile.nickname])
-    override val realname = SimpleStringProperty(config[ClientSpec.DefaultProfile.realname])
-    override val username = SimpleStringProperty(config[ClientSpec.DefaultProfile.username])
+    override val open = SimpleBooleanProperty(true).threadAsserting()
+    override val nickname = SimpleStringProperty(config[ClientSpec.DefaultProfile.nickname]).threadAsserting()
+    override val realname = SimpleStringProperty(config[ClientSpec.DefaultProfile.realname]).threadAsserting()
+    override val username = SimpleStringProperty(config[ClientSpec.DefaultProfile.username]).threadAsserting()
 
     override fun onSavePressed() {
         if (!valid.value) {
@@ -60,7 +59,9 @@ class SettingsDialogModel(private val controller: SettingsDialogContract.Control
 
     override fun onCancelPressed() = close()
 
-    private fun close() = open.set(false)
+    private fun close() {
+        open.value = false
+    }
 }
 
 class SettingsDialog(model: SettingsDialogContract.ViewModel, private val parent: ObjectProperty<Node>) : VBox() {

--- a/src/main/kotlin/com/dmdirc/Validating.kt
+++ b/src/main/kotlin/com/dmdirc/Validating.kt
@@ -1,8 +1,8 @@
 package com.dmdirc
 
 import javafx.beans.binding.BooleanExpression
+import javafx.beans.property.Property
 import javafx.beans.property.ReadOnlyBooleanPropertyBase
-import javafx.beans.property.StringProperty
 import javafx.beans.value.ChangeListener
 import javafx.scene.control.TextField
 import javafx.scene.control.TextInputControl
@@ -13,11 +13,11 @@ import org.controlsfx.validation.decoration.StyleClassValidationDecoration
 
 val requiredValidator: Validator<TextField> = Validator.createEmptyValidator<TextField>("Required")
 
-fun bindRequiredTextControl(c: TextInputControl, p: StringProperty, m: ValidatingModel) {
+fun bindRequiredTextControl(c: TextInputControl, p: Property<String>, m: ValidatingModel) {
     bindTextControl(c, p, requiredValidator, m)
 }
 
-fun bindTextControl(c: TextInputControl, p: StringProperty, v: Validator<TextField>, m: ValidatingModel) {
+fun bindTextControl(c: TextInputControl, p: Property<String>, v: Validator<TextField>, m: ValidatingModel) {
     val validationSupport = ValidationSupport()
     validationSupport.validationDecorator = StyleClassValidationDecoration("validation-error", "validation-warning")
     validationSupport.registerValidator(c, v)

--- a/src/main/kotlin/com/dmdirc/WindowUI.kt
+++ b/src/main/kotlin/com/dmdirc/WindowUI.kt
@@ -26,10 +26,9 @@ import com.jukusoft.i18n.I.tr
 import com.uchuhimo.konf.Item
 import javafx.application.HostServices
 import javafx.beans.Observable
-import javafx.beans.property.BooleanProperty
+import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleStringProperty
-import javafx.beans.property.StringProperty
 import javafx.collections.ListChangeListener
 import javafx.geometry.Orientation.VERTICAL
 import javafx.scene.control.ListView
@@ -54,14 +53,14 @@ class WindowModel(
     private val config: ClientConfig,
     connectionId: String?
 ) {
-    val name: StringProperty = SimpleStringProperty(initialName)
-    val title: StringProperty = SimpleStringProperty(initialName)
-    val hasUnreadMessages: BooleanProperty = SimpleBooleanProperty(false)
+    val name: Property<String> = SimpleStringProperty(initialName).threadAsserting()
+    val title: Property<String> = SimpleStringProperty(initialName).threadAsserting()
+    val hasUnreadMessages: Property<Boolean> = SimpleBooleanProperty(false).threadAsserting()
     val nickList = NickListModel()
     val isConnection = type == WindowType.SERVER
     val sortKey = "${connectionId ?: ""} ${if (isConnection) "" else initialName.toLowerCase()}"
     val lines = mutableListOf<Array<StyledSpan>>().observable()
-    val inputField: StringProperty = SimpleStringProperty("")
+    val inputField: Property<String> = SimpleStringProperty("").threadAsserting()
 
     companion object {
         fun extractor(): Callback<WindowModel, Array<Observable>> {
@@ -147,7 +146,7 @@ class WindowModel(
     )
 
     private fun addLine(spans: Sequence<StyledSpan>) {
-        hasUnreadMessages.set(true)
+        hasUnreadMessages.value = true
         lines.add(spans.toList().toTypedArray())
     }
 
@@ -166,7 +165,7 @@ class WindowModel(
 
 class WindowUI(model: WindowModel, hostServices: HostServices) : AnchorPane() {
 
-    internal var scrollbar: ScrollBar? = null
+    private var scrollbar: ScrollBar? = null
     private val textArea = IrcTextArea { url -> hostServices.showDocument(url) }
 
     init {

--- a/src/test/kotlin/com/dmdirc/ConnectDialogTest.kt
+++ b/src/test/kotlin/com/dmdirc/ConnectDialogTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import javafx.scene.control.TextFormatter.Change
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class ServerListControllerTest {
@@ -66,6 +67,11 @@ internal class ServerListModelTest {
     private val controller = mockk<ServerListController>()
     private val config = mockk<ClientConfig>()
     private val model = ServerListModel(controller, config)
+
+    @BeforeEach
+    fun setup() {
+        PlatformWrappers.fxThreadTester = { true }
+    }
 
     @Test
     fun `test connect pressed when null`() {

--- a/src/test/kotlin/com/dmdirc/FxUtilsTest.kt
+++ b/src/test/kotlin/com/dmdirc/FxUtilsTest.kt
@@ -1,0 +1,54 @@
+package com.dmdirc
+
+import com.bugsnag.Bugsnag
+import com.dmdirc.PlatformWrappers.fxThreadTester
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+internal class FxUtilsTest {
+
+    private val exception = slot<Throwable>()
+    private val mockBugsnag = mockk<Bugsnag> {
+        every { notify(capture(exception)) } returns true
+    }
+
+    private fun uiOperation() {
+        assertOnFxThread(mockBugsnag)
+    }
+
+    private fun doUiCall() {
+        uiOperation()
+    }
+
+    @Test
+    fun `assertOnFxThread puts method name in message`() {
+        fxThreadTester = { false }
+        doUiCall()
+        assertNotNull(exception.captured)
+        assertEquals(true, exception.captured.message?.startsWith("Function uiOperation must be called on the FX thread"))
+    }
+
+    @Test
+    fun `assertOnFxThread rewrites stack trace to point at the bad function`() {
+        fxThreadTester = { false }
+        doUiCall()
+        assertNotNull(exception.captured)
+        val firstMethod = exception.captured.stackTrace?.get(0)?.methodName
+        assertEquals("doUiCall", firstMethod)
+    }
+
+    @Test
+    fun `assertOnFxThread does nothing if on the fx thread`() {
+        fxThreadTester = { true }
+        doUiCall()
+        verify(inverse = true) {
+            mockBugsnag.notify(any<Throwable>())
+        }
+    }
+
+}

--- a/src/test/kotlin/com/dmdirc/FxUtilsTest.kt
+++ b/src/test/kotlin/com/dmdirc/FxUtilsTest.kt
@@ -50,5 +50,4 @@ internal class FxUtilsTest {
             mockBugsnag.notify(any<Throwable>())
         }
     }
-
 }

--- a/src/test/kotlin/com/dmdirc/ImagesTest.kt
+++ b/src/test/kotlin/com/dmdirc/ImagesTest.kt
@@ -1,5 +1,6 @@
 package com.dmdirc
 
+import com.dmdirc.PlatformWrappers.runLaterProvider
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertArrayEquals

--- a/src/test/kotlin/com/dmdirc/JoinDialogTest.kt
+++ b/src/test/kotlin/com/dmdirc/JoinDialogTest.kt
@@ -5,6 +5,7 @@ import io.mockk.verify
 import javafx.beans.property.SimpleBooleanProperty
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class JoinDialogControllerTest {
@@ -28,6 +29,11 @@ internal class JoinDialogModelTest {
     private val falseValidator = SimpleBooleanProperty(false)
     private val model = JoinDialogModel(mockController)
 
+    @BeforeEach
+    fun setup() {
+        PlatformWrappers.fxThreadTester = { true }
+    }
+
     @Test
     fun `defaults to dialog being open`() {
         assertTrue(model.open.value)
@@ -42,7 +48,7 @@ internal class JoinDialogModelTest {
     @Test
     fun `joins when valid and join pressed`() {
         model.valid.addValidator(truthValidator)
-        model.channel.set("#dmdirc")
+        model.channel.value = "#dmdirc"
         model.onJoinPressed()
         verify {
             mockController.join("#dmdirc")
@@ -52,7 +58,7 @@ internal class JoinDialogModelTest {
     @Test
     fun `closes when valid and join pressed`() {
         model.valid.addValidator(truthValidator)
-        model.channel.set("#dmdirc")
+        model.channel.value = "#dmdirc"
         model.onJoinPressed()
         assertFalse(model.open.value)
     }
@@ -60,7 +66,7 @@ internal class JoinDialogModelTest {
     @Test
     fun `joins when valid and text submitted`() {
         model.valid.addValidator(truthValidator)
-        model.channel.set("#dmdirc")
+        model.channel.value = "#dmdirc"
         model.onTextAction()
         verify {
             mockController.join("#dmdirc")
@@ -70,7 +76,7 @@ internal class JoinDialogModelTest {
     @Test
     fun `closes when valid and text submitted`() {
         model.valid.addValidator(truthValidator)
-        model.channel.set("#dmdirc")
+        model.channel.value = "#dmdirc"
         model.onTextAction()
         assertFalse(model.open.value)
     }

--- a/src/test/kotlin/com/dmdirc/MainControllerTest.kt
+++ b/src/test/kotlin/com/dmdirc/MainControllerTest.kt
@@ -30,7 +30,8 @@ internal class MainControllerTest {
 
     @BeforeEach
     fun setup() {
-        runLaterProvider = { it.run() }
+        PlatformWrappers.runLaterProvider = { it.run() }
+        PlatformWrappers.fxThreadTester = { true }
     }
 
     @Test

--- a/src/test/kotlin/com/dmdirc/SettingsModelTest.kt
+++ b/src/test/kotlin/com/dmdirc/SettingsModelTest.kt
@@ -5,12 +5,18 @@ import io.mockk.mockk
 import io.mockk.verify
 import javafx.beans.property.SimpleBooleanProperty
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 private class SettingsModelTest {
 
     private val mockController = mockk<SettingsDialogContract.Controller>()
     private val mockConfig = mockk<ClientConfig>()
+
+    @BeforeEach
+    fun setup() {
+        PlatformWrappers.fxThreadTester = { true }
+    }
 
     @Test
     fun `defaults profile fields to values from config`() {

--- a/src/test/kotlin/com/dmdirc/WindowModelTest.kt
+++ b/src/test/kotlin/com/dmdirc/WindowModelTest.kt
@@ -38,7 +38,8 @@ internal class WindowModelTest {
         I.init(File("translations"), Locale.ENGLISH, "messages")
         I.setLanguage(Locale.forLanguageTag("en-GB"))
         every { metaData.time } returns TestConstants.time
-        runLaterProvider = { it.run() }
+        PlatformWrappers.runLaterProvider = { it.run() }
+        PlatformWrappers.fxThreadTester = { true }
     }
 
     @Test


### PR DESCRIPTION
Add an assertion that reports calls on the wrong thread to
Bugsnag. Change most properties to use the generic Property<>
interface and wrap them in a class that asserts sets are on
the right thread.